### PR TITLE
Add spm support

### DIFF
--- a/package.json
+++ b/package.json
@@ -39,5 +39,8 @@
     "gulp-watch": "^0.6.8",
     "nib": "^1.0.3",
     "vinyl-source-stream": "^0.1.1"
+  },
+  "spm": {
+    "main": "src/rome.js"
   }
 }


### PR DESCRIPTION
A nicer package manager: http://spmjs.io
Documentation: http://spmjs.io/documentation

http://spmjs.io/package/rome

---

It is a package manager based on [Sea.js](https://github.com/seajs/seajs) which is a popular module loader in China.

spmjs focus in browser side. We supply a complete lifecycle managment of package by using [spm](https://github.com/spmjs/spm/tree/master).

> If you need ownership of rome in spmjs, I can add it for your account after signing in http://spmjs.io.
