### PR TITLE
Strict parse

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@ node_modules
 npm-debug.log
 .DS_Store
 Thumbs.db
+.idea

--- a/README.md
+++ b/README.md
@@ -73,6 +73,7 @@ Option             | Description
 `initialValue`     | Value used to initialize calendar. Takes `string`, `Date`, or `moment`
 `inputFormat`      | Format string used for the input field as well as the results of `rome`
 `invalidate`       | Ensures the date is valid when the field is blurred
+`strictParse`      | Ensures the date is of the given inputFormat before using it as value. The option is `false` by default
 `max`              | Disallow dates past `max`. Takes `string`, `Date`, or `moment`
 `min`              | Disallow dates before `min`. Takes `string`, `Date`, or `moment`
 `monthFormat`      | Format string used by the calendar to display months and their year

--- a/src/input.js
+++ b/src/input.js
@@ -110,7 +110,7 @@ function inputCalendar (input, calendarOptions) {
     if (isEmpty()) {
       return;
     }
-    var date = momentum.moment(value, o.inputFormat);
+    var date = momentum.moment(value, o.inputFormat, o.strictParse);
     api.setValue(date);
   }
 


### PR DESCRIPTION
Introduced `strictParse` option.

When true makes a strict parsing of the given input value. This should fix the problem discussed with #64