### PR TITLE
Update typos in documentation for rome.val.before.

### DIFF
--- a/README.md
+++ b/README.md
@@ -262,11 +262,11 @@ Returns whether the date is after the provided value. The comparison uses `>`, m
 
 #### `rome.val.beforeEq(value)`
 
-Returns whether the date is after the provided value. The comparison uses `<=`, meaning it's inclusive.
+Returns whether the date is before the provided value. The comparison uses `<=`, meaning it's inclusive.
 
 #### `rome.val.before(value)`
 
-Returns whether the date is after the provided value. The comparison uses `<`, meaning it's exclusive.
+Returns whether the date is before the provided value. The comparison uses `<`, meaning it's exclusive.
 
 #### `rome.val.except(left, right)`
 


### PR DESCRIPTION
The descriptions for `rome.val.before` and `rome.val.beforeEq` are copies of `after` and `afterEq`. 