### PR TITLE
time field highlighting when picked (for always open time picker)

### DIFF
--- a/dist/rome.standalone.js
+++ b/dist/rome.standalone.js
@@ -356,6 +356,7 @@ function calendar (calendarOptions) {
   var lastMonth;
   var lastDay;
   var lastDayElement;
+  var lastTimeElement;
   var datewrapper;
   var back;
   var next;
@@ -381,6 +382,7 @@ function calendar (calendarOptions) {
     lastYear = no;
     lastDay = no;
     lastDayElement = no;
+    lastTimeElement = no;
     o.appendTo.appendChild(container);
 
     removeChildren(container);
@@ -953,6 +955,15 @@ function calendar (calendarOptions) {
     var target = e.target;
     if (!classes.contains(target, o.styles.timeOption)) {
       return;
+    }
+    if (!classes.contains(target, o.styles.selectedTime)) {
+      if (lastTimeElement) {
+        classes.remove(lastTimeElement, o.styles.selectedTime);
+      }
+      if(target){
+        classes.add(target, o.styles.selectedTime);
+      }      
+      lastTimeElement = target;
     }
     var value = momentum.moment(text(target), o.timeFormat);
     setTime(ref, value);

--- a/src/calendar.js
+++ b/src/calendar.js
@@ -30,6 +30,7 @@ function calendar (calendarOptions) {
   var lastMonth;
   var lastDay;
   var lastDayElement;
+  var lastTimeElement;
   var datewrapper;
   var back;
   var next;
@@ -55,6 +56,7 @@ function calendar (calendarOptions) {
     lastYear = no;
     lastDay = no;
     lastDayElement = no;
+    lastTimeElement = no;
     o.appendTo.appendChild(container);
 
     removeChildren(container);
@@ -627,6 +629,15 @@ function calendar (calendarOptions) {
     var target = e.target;
     if (!classes.contains(target, o.styles.timeOption)) {
       return;
+    }
+    if (!classes.contains(target, o.styles.selectedTime)) {
+      if (lastTimeElement) {
+        classes.remove(lastTimeElement, o.styles.selectedTime);
+      }
+      if(target){
+        classes.add(target, o.styles.selectedTime);
+      }
+      lastTimeElement = target;
     }
     var value = momentum.moment(text(target), o.timeFormat);
     setTime(ref, value);


### PR DESCRIPTION
**this is setting the 'selected' class to the HTML element picked**, which is useful when the time picker stays always open and you want to provide visual feedback of the current choice made, similar to the calendar.

ideally this would be accompanied by a time setting, eg. timeAutoClose: 'never', which would avoid toggling the visibility of the picker. Currently, the workaround is to use CSS to force the time picker parent to always show. It works, but less elegantly. 

*this is my first pull req - feel free to implement properly, or even
drop it altogether ;-)*