### PR TITLE
Throw error one day interval between min and max only if there is no tim...

### DIFF
--- a/src/defaults.js
+++ b/src/defaults.js
@@ -47,7 +47,7 @@ function defaults (options, cal) {
       o.max = o.min;
       o.min = temp;
     }
-    if (o.date === true) {
+    if (o.time === false) {
       if (o.max.clone().subtract(1, 'days').isBefore(o.min)) {
         throw new Error('`max` must be at least one day after `min`');
       }


### PR DESCRIPTION
**Throw error one day interval between min and max only if there is no time picker**

Choose a datetime in the same day (eq: min `2015-03-09T10:00` and max `2015-03-09T18:00`) throw an error `max must be at least one day after min` but functionally it doesn't have to. Actually if we comment the error it work.

See the issue here :
http://jsbin.com/zaxinimuki/1/edit?html,output
(the datetime-local input is just to show that's, functionally, work on chrome android)

So I just changed the condition to only check it if time option is false.