### PR TITLE
Fix regression with input bullseye

### DIFF
--- a/src/input.js
+++ b/src/input.js
@@ -39,7 +39,7 @@ function inputCalendar (input, calendarOptions) {
       input.value = o.initialValue.format(o.inputFormat);
     }
 
-    eye = bullseye(api.container, input);
+    eye = bullseye(api.container, input, {});
     api.on('data', updateInput);
     api.on('show', eye.refresh);
 


### PR DESCRIPTION
Hello,

This change in bullseye 1.4.0 breaks the container positioning on the input, as the target is set to the container instead of the input: https://github.com/bevacqua/bullseye/commit/58f652190492cdf4fddc1a3926a0761e129259b3#diff-f04841aeae5d9da07d33be4a864276e5R12

Setting the third argument to bullseye fixes it.