### PR TITLE
Fixing IE error "Unable to get property 'removeChild' of undefined or nu...

### DIFF
--- a/src/calendar.js
+++ b/src/calendar.js
@@ -90,7 +90,7 @@ function calendar (calendarOptions) {
   }
 
   function destroy (silent) {
-    if (container) {
+    if (container && container.parentNode) {
       container.parentNode.removeChild(container);
     }
 


### PR DESCRIPTION
There's an issue in IE (10 and 11, did not check previous versions). After any date picker container is removed from DOM every other 'destroy' call on any other date picker causes the following error:
```
Unable to get property 'removeChild' of undefined or null reference
```
That happens in IE only, this edition fixes the issue.