### PR TITLE
Add 'back' and 'next' to API

### DIFF
--- a/README.md
+++ b/README.md
@@ -222,6 +222,16 @@ Sets the current date to the provided `value`, but only if that value is valid a
 
 Forces a refresh of the calendar. This method will redraw the month and update the dates that can be selected in accordance with `dateValidator` and `timeValidator`.
 
+##### `.back()`
+
+Steps the calendar display back by one month. Equivalent to clicking the 'back' button.
+Returns `undefined`.
+
+##### `.next()`
+
+Steps the calendar display forward by one month. Equivalent to clicking the 'next' button.
+Returns `undefined`.
+
 #### Events
 
 Rome calendars also provide a few events you can subscribe to. These events are published through an event emitter created using [`contra`][2]. These events are listed below.

--- a/README.md
+++ b/README.md
@@ -247,6 +247,8 @@ Event       | Arguments   | Description
 `time`      | `[time]`    | The time may have been updated by the calendar. Formatted time string is provided
 `show`      | `[]`        | The calendar has been displayed
 `hide`      | `[]`        | The calendar has been hidden
+`back`      | `[month]`   | The calendar view has been moved back a month to the value `moment.month()`
+`next`      | `[month]`   | The calendar view has been moved forward a month to the value `moment.month()`
 
 #### Date and Time Validator
 

--- a/src/calendar.js
+++ b/src/calendar.js
@@ -318,6 +318,7 @@ function calendar (calendarOptions) {
     ref = bound || ref;
     if (bound) { refCal = bound.clone(); }
     update();
+    api.emit(op === 'add' ? 'next' : 'back', ref.month());
   }
 
   function update (silent) {

--- a/src/calendar.js
+++ b/src/calendar.js
@@ -64,6 +64,7 @@ function calendar (calendarOptions) {
     ref = o.initialValue ? o.initialValue : momentum.moment();
     refCal = ref.clone();
 
+    api.back = subtractMonth;
     api.container = container;
     api.destroyed = false;
     api.destroy = destroy.bind(api, false);
@@ -72,6 +73,7 @@ function calendar (calendarOptions) {
     api.getDateString = getDateString;
     api.getMoment = getMoment;
     api.hide = hide;
+    api.next = addMonth;
     api.options = changeOptions;
     api.options.reset = resetOptions;
     api.refresh = refresh;
@@ -99,6 +101,7 @@ function calendar (calendarOptions) {
     }
 
     var destroyed = api.emitterSnapshot('destroyed');
+    api.back = noop;
     api.destroyed = true;
     api.destroy = napi;
     api.emitValues = napi;
@@ -106,6 +109,7 @@ function calendar (calendarOptions) {
     api.getDateString = noop;
     api.getMoment = noop;
     api.hide = napi;
+    api.next = noop;
     api.options = napi;
     api.options.reset = napi;
     api.refresh = napi;


### PR DESCRIPTION
I've been working with Rome not just for input but for display, and found it useful to be able to access the navigation functions via API. Thought I'd put in a pull request in case you thought this was useful too. Second commit is to add 'back' and 'next' events explicitly.