### PR TITLE
`freeNav` option to navigate out of bound months

### DIFF
--- a/README.md
+++ b/README.md
@@ -70,6 +70,7 @@ Option             | Description
 `date`             | The calendar shows days and allows you to navigate between months
 `dateValidator`    | Function to validate that a given date is considered valid. Receives a native `Date` parameter.
 `dayFormat`        | Format string used to display days on the calendar
+`freeNav`          | Enables date navigation to months prior to the current month (default: `false`)
 `initialValue`     | Value used to initialize calendar. Takes `string`, `Date`, or `moment`
 `inputFormat`      | Format string used for the input field as well as the results of `rome`
 `invalidate`       | Ensures the date is valid when the field is blurred

--- a/src/calendar.js
+++ b/src/calendar.js
@@ -165,7 +165,7 @@ function calendar (calendarOptions) {
 
     crossvent.add(back, 'click', subtractMonth);
     crossvent.add(next, 'click', addMonth);
-    crossvent.add(datewrapper, 'click', pickDay);
+    if (!o.freeNav) crossvent.add(datewrapper, 'click', pickDay);
 
     function renderMonth (i) {
       var month = dom({ className: o.styles.month, parent: datewrapper });
@@ -310,9 +310,11 @@ function calendar (calendarOptions) {
     var direction = op === 'add' ? -1 : 1;
     var offset = o.monthsInCalendar + direction * getMonthOffset(lastDayElement);
     refCal[op](offset, 'months');
-    bound = inRange(refCal.clone());
-    ref = bound || ref;
-    if (bound) { refCal = bound.clone(); }
+    if (!o.freeNav) {
+      bound = inRange(refCal.clone());
+      ref = bound || ref;
+      if (bound) { refCal = bound.clone(); }
+    }
     update();
   }
 
@@ -478,8 +480,8 @@ function calendar (calendarOptions) {
       cell: nextMonth
     });
 
-    back.disabled = !isInRangeLeft(first, true);
-    next.disabled = !isInRangeRight(lastDay, true);
+    back.disabled = !o.freeNav && !isInRange(first, true);
+    next.disabled = !o.freeNav && !isInRange(lastDay, true);
     month.date = offsetCal.clone();
 
     function part (data) {

--- a/src/defaults.js
+++ b/src/defaults.js
@@ -19,6 +19,7 @@ function defaults (options, cal) {
       throw new Error('Inline calendars must be appended to a parent node explicitly.');
     }
   }
+  if (o.freeNav === no) { o.freeNav = false; } // Navigate to months outside bounds
   if (o.invalidate === no) { o.invalidate = true; }
   if (o.required === no) { o.required = false; }
   if (o.date === no) { o.date = true; }


### PR DESCRIPTION
Hi Nicolas, another feature I've found fairly useful regarding usage of rome in a display capacity. Providing a PR if you think this is worth including.

Happy to change the `freeNav` option flag to something else, it seemed good enough at the time.