### PR TITLE
Stop 'hide' event from firing when calendar is already hidden

### DIFF
--- a/src/calendar.js
+++ b/src/calendar.js
@@ -254,7 +254,11 @@ function calendar (calendarOptions) {
   function showTimeList () { if (timelist) { timelist.style.display = 'block'; } }
   function hideTimeList () { if (timelist) { timelist.style.display = 'none'; } }
   function showCalendar () { container.style.display = 'inline-block'; api.emit('show'); }
-  function hideCalendar () { container.style.display = 'none'; api.emit('hide'); }
+  function hideCalendar () {
+    if (container.style.display !== 'none') {
+      container.style.display = 'none'; api.emit('hide');
+    }
+  }
 
   function show () {
     render();

--- a/src/calendar.js
+++ b/src/calendar.js
@@ -256,7 +256,8 @@ function calendar (calendarOptions) {
   function showCalendar () { container.style.display = 'inline-block'; api.emit('show'); }
   function hideCalendar () {
     if (container.style.display !== 'none') {
-      container.style.display = 'none'; api.emit('hide');
+      container.style.display = 'none';
+      api.emit('hide');
     }
   }
 


### PR DESCRIPTION
Added check to hideCalendar() function to avoid calling the hide event when the calendar was already hidden.

Without this the hide event is called every time the user clicks the mouse.