### PR TITLE
Added watchify to gulp setup for fast dev builds

### DIFF
--- a/gulpfile.js
+++ b/gulpfile.js
@@ -38,8 +38,7 @@ gulp.task('clean', function () {
 
 gulp.task('build-only-broad', bab);
 
-gulp.task('build-only', build);
-gulp.task('build-only:dev', buildDev);
+gulp.task('build:dev', buildDev);
 gulp.task('build', ['styles'], bab);
 
 function buildSource (src, dest, devMode) {
@@ -93,7 +92,6 @@ function bab () {
 gulp.task('styles:dev', function() {
   watch({ glob: 'src/**/*.styl' }, function () { gulp.start('styles-only'); });
 });
-
 gulp.task('styles-only', styles);
 gulp.task('styles', ['clean', 'bump'], styles);
 
@@ -113,7 +111,7 @@ function styles () {
     .pipe(gulp.dest('./dist'));
 }
 
-gulp.task('watch', ['styles:dev', 'build-only:dev']);
+gulp.task('watch', ['styles:dev', 'build:dev']);
 
 gulp.task('bump', function () {
   var bumpType = process.env.BUMP || 'patch'; // major.minor.patch

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -1,5 +1,3 @@
-'use strict';
-
 var path = require('path');
 var gulp = require('gulp');
 var bump = require('gulp-bump');
@@ -15,6 +13,9 @@ var streamify = require('gulp-streamify');
 var watch = require('gulp-watch');
 var source = require('vinyl-source-stream');
 var size = require('gulp-size');
+var watchify = require('watchify');
+var assign = require('lodash.assign');
+var gutil = require('gulp-util');
 
 var extended = [
   '/**',
@@ -38,31 +39,60 @@ gulp.task('clean', function () {
 gulp.task('build-only-broad', bab);
 
 gulp.task('build-only', build);
+gulp.task('build-only:dev', buildDev);
 gulp.task('build', ['styles'], bab);
 
-function buildSource (src, dest) {
+function buildSource (src, dest, devMode) {
   var pkg = require('./package.json');
+  var opts;
+  var b;
   var min = dest.split('.');
   min.splice(min.length - 1, 0, 'min');
   min = min.join('.');
-  return browserify('./src/' + src)
-    .bundle({ debug: true, standalone: 'rome' })
-    .pipe(source(dest))
-    .pipe(streamify(header(extended, { pkg : pkg } )))
-    .pipe(gulp.dest('./dist'))
-    .pipe(streamify(rename(min)))
-    .pipe(streamify(uglify()))
-    .pipe(streamify(header(succjs, { pkg : pkg } )))
-    .pipe(streamify(size()))
-    .pipe(gulp.dest('./dist'));
+
+  // browserify options
+  opts = {
+      entries: ['./src/' + src],
+      debug: true,
+      standalone: 'rome'
+  };
+
+  if (devMode) {
+    opts = assign({}, watchify.args, opts);
+    b = watchify(browserify(opts));
+    b.on('update', bundle);
+  } else {
+    b = browserify(opts);
+  }
+
+  b.on('log', gutil.log);
+
+  function bundle() {
+    return b.bundle()
+      .pipe(source(dest))
+      .pipe(streamify(header(extended, { pkg : pkg } )))
+      .pipe(gulp.dest('./dist'))
+      .pipe(streamify(rename(min)))
+      .pipe(streamify(uglify()))
+      .pipe(streamify(header(succjs, { pkg : pkg } )))
+      .pipe(streamify(size()))
+      .pipe(gulp.dest('./dist'));
+  }
+
+  return bundle();
 }
 
+function buildDev () { return buildSource('rome.moment.js', 'rome.js', true); }
 function build () { return buildSource('rome.moment.js', 'rome.js'); }
 function buildAlone () { return buildSource('rome.standalone.js', 'rome.standalone.js'); }
 function bab () {
   buildAlone();
   return build();
 }
+
+gulp.task('styles:dev', function() {
+  watch({ glob: 'src/**/*.styl' }, function () { gulp.start('styles-only'); });
+});
 
 gulp.task('styles-only', styles);
 gulp.task('styles', ['clean', 'bump'], styles);
@@ -83,10 +113,7 @@ function styles () {
     .pipe(gulp.dest('./dist'));
 }
 
-gulp.task('watch', function() {
-  watch({ glob: 'src/**/*.js' }, function () { gulp.start('build-only'); });
-  watch({ glob: 'src/**/*.styl' }, function () { gulp.start('styles-only'); });
-});
+gulp.task('watch', ['styles:dev', 'build-only:dev']);
 
 gulp.task('bump', function () {
   var bumpType = process.env.BUMP || 'patch'; // major.minor.patch

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -1,3 +1,5 @@
+'use strict';
+
 var path = require('path');
 var gulp = require('gulp');
 var bump = require('gulp-bump');
@@ -38,7 +40,7 @@ gulp.task('clean', function () {
 
 gulp.task('build-only-broad', bab);
 
-gulp.task('build:dev', buildDev);
+gulp.task('build-only', buildDev);
 gulp.task('build', ['styles'], bab);
 
 function buildSource (src, dest, devMode) {
@@ -111,7 +113,7 @@ function styles () {
     .pipe(gulp.dest('./dist'));
 }
 
-gulp.task('watch', ['styles:dev', 'build:dev']);
+gulp.task('watch', ['styles:dev', 'build-only']);
 
 gulp.task('bump', function () {
   var bumpType = process.env.BUMP || 'patch'; // major.minor.patch

--- a/package.json
+++ b/package.json
@@ -24,7 +24,7 @@
     "moment": "^2.8.2"
   },
   "devDependencies": {
-    "browserify": "^4.2.1",
+    "browserify": "^10.2.4",
     "gulp": "^3.8.6",
     "gulp-bump": "^0.1.8",
     "gulp-clean": "^0.2.4",
@@ -36,8 +36,11 @@
     "gulp-streamify": "0.0.5",
     "gulp-stylus": "^1.0.0",
     "gulp-uglify": "^0.3.0",
+    "gulp-util": "^3.0.6",
     "gulp-watch": "^0.6.8",
+    "lodash.assign": "^3.2.0",
     "nib": "^1.0.3",
-    "vinyl-source-stream": "^0.1.1"
+    "vinyl-source-stream": "^0.1.1",
+    "watchify": "^3.2.3"
   }
 }


### PR DESCRIPTION
Had to updated browserify to the latest version to get it to play nicely with the latest watchify.
Also added 'gulp-util' and 'lodash.assign' packages.