### PR TITLE
Use the del package instead of the deprecated gulp-clean

### DIFF
--- a/gulpfile.js
+++ b/gulpfile.js
@@ -4,7 +4,7 @@ var path = require('path');
 var gulp = require('gulp');
 var bump = require('gulp-bump');
 var git = require('gulp-git');
-var clean = require('gulp-clean');
+var clean = require('del');
 var rename = require('gulp-rename');
 var header = require('gulp-header');
 var uglify = require('gulp-uglify');
@@ -33,9 +33,8 @@ var succint = ' <%= pkg.name %>@v<%= pkg.version %>, <%= pkg.license %> licensed
 var succjs = '//' + succint + '\n';
 var succss = '/*' + succint + ' */\n';
 
-gulp.task('clean', function () {
-  gulp.src('./dist', { read: false })
-    .pipe(clean());
+gulp.task('clean', function (cb) {
+  del(['./dist'], cb);
 });
 
 gulp.task('build-only-broad', bab);

--- a/package.json
+++ b/package.json
@@ -25,9 +25,9 @@
   },
   "devDependencies": {
     "browserify": "^10.2.4",
+    "del": "^2.0.2",
     "gulp": "^3.8.6",
     "gulp-bump": "^0.1.8",
-    "gulp-clean": "^0.2.4",
     "gulp-git": "^0.4.2",
     "gulp-header": "^1.0.2",
     "gulp-minify-css": "^0.3.4",


### PR DESCRIPTION
`gulp-clean` [has been deprecated](https://github.com/peter-vilja/gulp-clean#deprecated-use-del-instead) since June 2014; additionally, the package causes `npm install` to fail under newer versions of node. This PR replaces `gulp-clean` with the [`del`](https://github.com/sindresorhus/del) package, which seems to be the most widely accepted replacement.