### PR TITLE
Toggle visibility with classes rather than style

### DIFF
--- a/README.md
+++ b/README.md
@@ -125,6 +125,7 @@ If you don't set an option, the default will be used. You can [look up the defau
   "styles": {
     "back": "rd-back",
     "container": "rd-container",
+    "containerActive": "rd-container-active",
     "date": "rd-date",
     "dayBody": "rd-days-body",
     "dayBodyElem": "rd-day-body",

--- a/README.md
+++ b/README.md
@@ -142,6 +142,7 @@ If you don't set an option, the default will be used. You can [look up the defau
     "selectedTime": "rd-time-selected",
     "time": "rd-time",
     "timeList": "rd-time-list",
+    "timeListActive": "rd-time-list-active",
     "timeOption": "rd-time-option"
   },
   "time": true,

--- a/src/calendar.js
+++ b/src/calendar.js
@@ -243,7 +243,7 @@ function calendar (calendarOptions) {
   }
 
   function toggleTimeList (show) {
-    var display = typeof show === 'boolean' ? show : timelist.style.display === 'none';
+    var display = typeof show === 'boolean' ? show : !classes.contains(timelist, o.styles.timeListActive);
     if (display) {
       showTimeList();
     } else {
@@ -251,8 +251,8 @@ function calendar (calendarOptions) {
     }
   }
 
-  function showTimeList () { if (timelist) { timelist.style.display = 'block'; } }
-  function hideTimeList () { if (timelist) { timelist.style.display = 'none'; } }
+  function showTimeList () { if (timelist) { classes.add(timelist, o.styles.timeListActive); } }
+  function hideTimeList () { if (timelist) { classes.remove(timelist, o.styles.timeListActive); } }
   function showCalendar () { container.style.display = 'inline-block'; api.emit('show'); }
   function hideCalendar () {
     if (container.style.display !== 'none') {

--- a/src/calendar.js
+++ b/src/calendar.js
@@ -253,10 +253,10 @@ function calendar (calendarOptions) {
 
   function showTimeList () { if (timelist) { classes.add(timelist, o.styles.timeListActive); } }
   function hideTimeList () { if (timelist) { classes.remove(timelist, o.styles.timeListActive); } }
-  function showCalendar () { container.style.display = 'inline-block'; api.emit('show'); }
+  function showCalendar () { classes.add(container, o.styles.containerActive); api.emit('show'); }
   function hideCalendar () {
-    if (container.style.display !== 'none') {
-      container.style.display = 'none';
+    if (classes.contains(container, o.styles.containerActive)) {
+      classes.remove(container, o.styles.containerActive);
       api.emit('hide');
     }
   }

--- a/src/defaults.js
+++ b/src/defaults.js
@@ -79,6 +79,7 @@ function defaults (options, cal) {
   var styl = o.styles;
   if (styl.back === no) { styl.back = 'rd-back'; }
   if (styl.container === no) { styl.container = 'rd-container'; }
+  if (styl.containerActive === no) { styl.containerActive = 'rd-container-active'; }
   if (styl.positioned === no) { styl.positioned = 'rd-container-attachment'; }
   if (styl.date === no) { styl.date = 'rd-date'; }
   if (styl.dayBody === no) { styl.dayBody = 'rd-days-body'; }

--- a/src/defaults.js
+++ b/src/defaults.js
@@ -98,6 +98,7 @@ function defaults (options, cal) {
   if (styl.selectedTime === no) { styl.selectedTime = 'rd-time-selected'; }
   if (styl.time === no) { styl.time = 'rd-time'; }
   if (styl.timeList === no) { styl.timeList = 'rd-time-list'; }
+  if (styl.timeListActive === no) { styl.timeListActive = 'rd-time-list-active'; }
   if (styl.timeOption === no) { styl.timeOption = 'rd-time-option'; }
 
   return o;

--- a/src/rome.styl
+++ b/src/rome.styl
@@ -5,6 +5,9 @@
   padding 10px
   text-align center
 
+.rd-container-active
+  display inline-block
+
 .rd-container-attachment
   position absolute
 

--- a/src/rome.styl
+++ b/src/rome.styl
@@ -76,6 +76,9 @@
   background-color #fff
   color #333
 
+.rd-time-list-active
+  display block
+
 .rd-time-selected
   padding 5px
 


### PR DESCRIPTION
Finally got to this as promised in #99.

I refactored the methods which toggle the visibility of the date picker container, as well as the time list to apply a class rather than directly modifying the display style. As mentioned in the issue, among other things, this means that rome can be easily animated using CSS animations.

As an aside, apologies in advance if there's anything wrong with my PRs, I don't often contribute to projects other than my own, so I'm not 100% sure of the process I should follow :smile: 
