### PR TITLE
Bugfix for issue #86

### DIFF
--- a/src/calendar.js
+++ b/src/calendar.js
@@ -9,7 +9,7 @@ var clone = require('./clone');
 var defaults = require('./defaults');
 var momentum = require('./momentum');
 var classes = require('./classes');
-var isInput = require('./isInput.js');
+var isInput = require('./isInput');
 var noop = require('./noop');
 var no;
 

--- a/src/calendar.js
+++ b/src/calendar.js
@@ -9,6 +9,7 @@ var clone = require('./clone');
 var defaults = require('./defaults');
 var momentum = require('./momentum');
 var classes = require('./classes');
+var isInput = require('./isInput.js');
 var noop = require('./noop');
 var no;
 
@@ -266,6 +267,9 @@ function calendar (calendarOptions) {
     refresh();
     toggleTimeList(!o.date);
     showCalendar();
+    if (!o.date && !isInput(this.associated)) {
+      hideTimeList();
+    }
     return api;
   }
 


### PR DESCRIPTION
This hides the timelist initially, if `date` is `false` and element is inline.