### PR TITLE
Allow calendar to work with any numerals

### DIFF
--- a/src/calendar.js
+++ b/src/calendar.js
@@ -505,6 +505,7 @@ function calendar (calendarOptions) {
           text: day.format(o.dayFormat),
           className: validationTest(day, data.cell.join(' ').split(' ')).join(' ')
         });
+        node.setAttribute('data-date', day.date());
         if (data.selectable && day.date() === current) {
           selectDayElement(node);
         }
@@ -591,7 +592,7 @@ function calendar (calendarOptions) {
     if (classes.contains(target, o.styles.dayDisabled) || !classes.contains(target, o.styles.dayBodyElem)) {
       return;
     }
-    var day = parseInt(text(target), 10);
+    var day = target.getAttribute('data-date');
     var prev = classes.contains(target, o.styles.dayPrevMonth);
     var next = classes.contains(target, o.styles.dayNextMonth);
     var offset = getMonthOffset(target) - getMonthOffset(lastDayElement);


### PR DESCRIPTION
Because of the use of the text string and `parseInt()` to get the date value from the calendar, rome was breaking when localized to a system that does not use western-arabic numerals [0, 1, 2, 3...].

By adding the `moment.date()` value to a custom attributes tag, `data-date`, we can be sure that the value returned will always be the correct date value.
