### PR TITLE
Bump contra dependency. Fixes #176.

### DIFF
--- a/package.json
+++ b/package.json
@@ -19,7 +19,7 @@
   "main": "src/rome.moment.js",
   "dependencies": {
     "bullseye": "1.4.6",
-    "contra": "1.9.1",
+    "contra": "^1.9.4",
     "crossvent": "1.5.0",
     "moment": "^2.8.2"
   },


### PR DESCRIPTION
Contra 1.9.4 depends on a later version of `ticky`. The version that
 1.9.1 depends on has a bug which prevents rome from being used in
 rollup bundles.